### PR TITLE
Fetch synonyms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /node_modules/
 /public/build/
+/rollup.config.js/
 
 .DS_Store
+.rollup.config.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,16 @@
         "resolve": "^1.14.2"
       }
     },
+    "@rollup/plugin-replace": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.1.tgz",
+      "integrity": "sha512-qDcXj2VOa5+j0iudjb+LiwZHvBRRgWbHPhRmo1qde2KItTjuxDVQO21rp9/jOlzKR5YO0EsgRQoyox7fnL7y/A==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.4",
+        "magic-string": "^0.25.5"
+      }
+    },
     "@rollup/pluginutils": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.0",
     "@rollup/plugin-node-resolve": "^7.0.0",
+    "@rollup/plugin-replace": "^2.3.1",
     "rollup": "^1.20.0",
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-svelte": "^5.0.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import svelte from 'rollup-plugin-svelte';
+import replace from '@rollup/plugin-replace';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import livereload from 'rollup-plugin-livereload';
@@ -15,6 +16,10 @@ export default {
 		file: 'public/build/bundle.js'
 	},
 	plugins: [
+		replace({ 
+			API_KEY: 'c465fb9f-f231-4723-abe4-e8969e5741a8',
+			delimiters: ['', ''] 
+		}),
 		svelte({
 			// enable run-time checks when not in production
 			dev: !production,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,16 +1,26 @@
 <script>
-	import Form from './Form.svelte'
-	import Button from './Button.svelte'
+	import 
+	import Form from './Form.svelte';
+	import Button from './Button.svelte';
+
+	let synonyms = [];
+
+	const getSynonyms = async (event) => {
+    await fetch(`https://www.dictionaryapi.com/api/v3/references/thesaurus/json/${event.detail.text}?key=API_KEY`)
+      .then(res => res.json())
+      .then(data => synonyms = data[0].meta.syns)
+      .catch(err => console.log(err))
+	}
 </script>
 
 <main>
 	<p>Struggling with a word?</p>
 	<h1>Next Word Please!</h1>
 	<p>Give us one</p>
-	<Form />
+	<Form on:message={getSynonyms}/>
 	<p>We'll give you a few:</p>
 	<section class="button-container">
-		<Button />
+		<Button data={synonyms}/>
 	</section>
 </main>
 

--- a/src/Form.svelte
+++ b/src/Form.svelte
@@ -1,6 +1,16 @@
+<script>
+  let word = '';
+
+  const getSynonyms = async () => {
+    await fetch(`https://www.dictionaryapi.com/api/v3/references/thesaurus/json/${word}?key=`)
+      .then(res => res.json() )
+      .then(data => console.log(data[0].meta.syns))
+	}
+</script>
+
 <form>
-  <input type="text">
-  <button class="submit-btn" type="button">Submit</button>
+  <input type="text" bind:value={word}>
+  <button class="submit-btn" type="button" on:click={getSynonyms}>Submit</button>
 </form>
 
 

--- a/src/Form.svelte
+++ b/src/Form.svelte
@@ -1,16 +1,19 @@
 <script>
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+
   let word = '';
 
-  const getSynonyms = async () => {
-    await fetch(`https://www.dictionaryapi.com/api/v3/references/thesaurus/json/${word}?key=`)
-      .then(res => res.json() )
-      .then(data => console.log(data[0].meta.syns))
-	}
+  const clickHandler = () => {
+    dispatch('message', {
+      text: word
+    })
+  }
 </script>
 
 <form>
   <input type="text" bind:value={word}>
-  <button class="submit-btn" type="button" on:click={getSynonyms}>Submit</button>
+  <button class="submit-btn" type="button" on:click={clickHandler}>Submit</button>
 </form>
 
 


### PR DESCRIPTION
### What's this PR do?
This PR introduces fetch functionality and was supposed to hide the API_KEY.  I have struggled with the api key for too long the issue will remain open.  I will move on to fixing the layout of the application. 

### Where should the reviewer start?
This PR adds a dev dependency the rollup plugin to "help" hide the API_KEY.  Take a look at App.svelte to see the added fetch.  Fetch call will be invoked when the App component hears the triggered event on the Form component.  In the Form.svelte file you will see that we are binding the value of the input field and using the createEventDispatch provided by svelte to pass the input value up to the fetch call.

### How should this be manually tested?
In order to test pull down and run ```npm i ``` to get the new dependency.  Open a web browser and go to localhost:5000/? and type a word into the input.  You should see the button component render with all the words crammed into one button ( will add logic to render multiple buttons ).

### Any background context you want to provide?
I was hoping to hide my API_Key using the rollup plugin but was unsuccessful in ignoring the rollup.config.js file.  I want to continue working on other functionality for this challenge,  the issue will remain open and be addressed at a later date.
### What are the relevant tickets?
#3 
#4 
### Screenshot:
 
![Screen Shot 2020-03-03 at 2 29 16 PM](https://user-images.githubusercontent.com/45470456/75821394-69673500-5d5b-11ea-87ad-460995dd32b0.png)
