### PR TITLE
Render synonyms

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -22,7 +22,7 @@
 	<p>We'll give you a few:</p>
 	<section class="button-container">
 		{#each synonyms as synonym}
-			<Button data={synonym}/>
+			<Button data={synonym} on:message={getSynonyms}/>
 		{/each}
 	</section>
 </main>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,4 @@
 <script>
-	import 
 	import Form from './Form.svelte';
 	import Button from './Button.svelte';
 
@@ -8,7 +7,9 @@
 	const getSynonyms = async (event) => {
     await fetch(`https://www.dictionaryapi.com/api/v3/references/thesaurus/json/${event.detail.text}?key=API_KEY`)
       .then(res => res.json())
-      .then(data => synonyms = data[0].meta.syns)
+      .then(data => {
+				synonyms = data[0].meta.syns[0]
+				})
       .catch(err => console.log(err))
 	}
 </script>
@@ -20,7 +21,9 @@
 	<Form on:message={getSynonyms}/>
 	<p>We'll give you a few:</p>
 	<section class="button-container">
-		<Button data={synonyms}/>
+		{#each synonyms as synonym}
+			<Button data={synonym}/>
+		{/each}
 	</section>
 </main>
 

--- a/src/Button.svelte
+++ b/src/Button.svelte
@@ -1,8 +1,16 @@
 <script>
-  export let data
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+
+  export let data;
+  const clickHandler = () => {
+    dispatch('message', {
+      text: data
+    })
+  }
 </script>
 
-<button class='synonyms' type="button">{data}</button>
+<button class='synonyms' type="button" on:click={clickHandler}>{data}</button>
 
 <style>
   .synonyms {


### PR DESCRIPTION
### What's this PR do?
This PR adds functionality to dynamically render buttons with different words from the fetch's response.  It also adds functionality to the buttons so that they can send a request to get synonyms for the words rendered on the buttons themselves.  You can continuously click on buttons to get different suggestions.
### Where should the reviewer start?
App.svelte and Button.svelte are the only files with changes.  In App.svelte you can see the addition of an each statement that iterates over the synonyms array to dynamically render buttons to the page.  In the Button.svelte file you can see we added the createEventDispatch method from Svelte so that we can pass a new query word back up to the fetch call.  
### How should this be manually tested?
This PR does not add any new dependencies, you can pull down, run ```npm run dev```, open a web browser to localhost:5000/?, and input a word to test out the functionality.
### What are the relevant tickets?
#4 
### Screenshots (if appropriate)
![Screen Shot 2020-03-03 at 3 10 22 PM](https://user-images.githubusercontent.com/45470456/75824648-1f814d80-5d61-11ea-878f-6dc4c767167d.png)
